### PR TITLE
Add nodeSelector to Heketi deployments

### DIFF
--- a/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
@@ -61,6 +61,8 @@ objects:
           glusterfs: deploy-heketi-${CLUSTER_NAME}-pod
           deploy-heketi: support
       spec:
+        nodeSelector:
+          type: ${HEKETI_NODE_SELECTOR}
         serviceAccountName: heketi-${CLUSTER_NAME}-service-account
         containers:
         - name: heketi
@@ -131,3 +133,7 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
+- name: HEKETI_NODE_SELECTOR
+  displayName: Heketi node selector
+  description: A node selector for the Heketi deployment
+  value: "master"

--- a/roles/openshift_storage_glusterfs/files/heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/heketi-template.yml
@@ -61,6 +61,8 @@ objects:
           glusterfs: heketi-${CLUSTER_NAME}-pod
           heketi: ${CLUSTER_NAME}-pod
       spec:
+        nodeSelector:
+          type: ${HEKETI_NODE_SELECTOR}
         serviceAccountName: heketi-${CLUSTER_NAME}-service-account
         containers:
         - name: heketi
@@ -143,3 +145,7 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
+- name: HEKETI_NODE_SELECTOR
+  displayName: Heketi node selector
+  description: A node selector for the Heketi deployment
+  value: "master"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
@@ -47,3 +47,4 @@
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_heketi_fstab }}"
     glusterfs_nodes: "{{ groups.glusterfs | default([]) }}"
+    heketi_node_selector: "{{ openshift_heketi_node_selector | default('master') }}"

--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy.yml
@@ -54,6 +54,7 @@
       HEKETI_EXECUTOR: "{{ glusterfs_heketi_executor }}"
       HEKETI_FSTAB: "{{ glusterfs_heketi_fstab }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
+      HEKETI_NODE_SELECTOR: "{{ heketi_node_selector }}"
 
 - name: Wait for heketi pod
   oc_obj:

--- a/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
@@ -28,6 +28,7 @@
       HEKETI_EXECUTOR: "{{ glusterfs_heketi_executor }}"
       HEKETI_FSTAB: "{{ glusterfs_heketi_fstab }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
+      HEKETI_NODE_SELECTOR: "{{ heketi_node_selector }}"
 
 - name: Wait for deploy-heketi pod
   oc_obj:


### PR DESCRIPTION
Added a nodeSelector to Heketi deployments via:
`openshift_heketi_node_selector`. This was needed in order to
make sure that the Heketi pod lands on a node which has the
correct access rights to the GlusterFS hosts (When SSH is needed).